### PR TITLE
modified robots detection

### DIFF
--- a/pkg/recursebuster/structs.go
+++ b/pkg/recursebuster/structs.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -554,7 +555,20 @@ func (gState *State) getRobots(u url.URL) {
 		gState.PrintOutput("Robots Error: \n"+err.Error(), Error, 1)
 		return
 	}
+	// Check that the file is actually a plaintext robots.txt and not a soft404
+	re, err := regexp.Compile(`(?i)<\s?html\s?>`)
+	if err != nil {
+		gState.PrintOutput("Robots Error: \n"+err.Error(), Error, 1)
+		return
+	}
+	if re.Match(content) {
+		// Soft404 or some other dodgy robots.txt discovered
+		gState.PrintOutput("Robots Error: \n"+"Unexpected robots.txt content (contained html?)", Error, 1)
+		return
+	}
+
 	//parse robots.txt
+
 	contents := strings.Split(string(content), "\n")
 	for _, line := range contents {
 		//split into parts

--- a/pkg/recursebuster/structs.go
+++ b/pkg/recursebuster/structs.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -552,6 +553,18 @@ func (gState *State) getRobots(u url.URL) {
 	content, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		gState.PrintOutput("Robots Error: \n"+err.Error(), Error, 1)
+		return
+	}
+
+	// Check that the file is actually a plaintext robots.txt and not a soft404
+	re, err := regexp.Compile(`(?i)<\s?html\s?>`)
+	if err != nil {
+		gState.PrintOutput("Robots Error: \n"+err.Error(), Error, 1)
+		return
+	}
+	if re.Match(content) {
+		// Soft404 or some other dodgy robots.txt discovered
+		gState.PrintOutput("Robots Error: \n"+"Unexpected robots.txt content (contained html?)", Error, 1)
 		return
 	}
 	//parse robots.txt

--- a/test/main_test.go
+++ b/test/main_test.go
@@ -587,7 +587,7 @@ func TestBadRobotsBod(t *testing.T) {
 	finished := make(chan struct{})
 	cfg := getDefaultConfig()
 	cfg.Headers = recursebuster.ArrayStringFlag{}
-	cfg.Headers.Set("badrobotman:lol")
+	cfg.Headers.Set("badrobotman: lol")
 	gState, urlSlice := preSetupTest(cfg, "2025", finished, t)
 	found := postSetupTest(urlSlice, gState)
 	gState.Wait()

--- a/test/main_test.go
+++ b/test/main_test.go
@@ -586,12 +586,13 @@ func TestBadRobotsBod(t *testing.T) {
 	t.Parallel()
 	finished := make(chan struct{})
 	cfg := getDefaultConfig()
+	cfg.Headers = recursebuster.ArrayStringFlag{}
+	cfg.Headers.Set("badrobotman:lol")
 	gState, urlSlice := preSetupTest(cfg, "2025", finished, t)
-	gState.WordList = append(gState.WordList, "badrobots.txt")
 	found := postSetupTest(urlSlice, gState)
 	gState.Wait()
-	if x, ok := found["/badrobots.txt"]; ok || x != nil {
-		t.Error(fmt.Sprintf("Failed test, did not expect to find %s", "/badrobots.txt (bad body contents)"))
+	if x, ok := found["/robots.txt"]; ok || x != nil {
+		t.Error(fmt.Sprintf("Failed test, did not expect to find %s", "/robots.txt (bad body contents)"))
 	}
 
 }

--- a/test/main_test.go
+++ b/test/main_test.go
@@ -582,6 +582,20 @@ func TestBadBod(t *testing.T) {
 
 }
 
+func TestBadRobotsBod(t *testing.T) {
+	t.Parallel()
+	finished := make(chan struct{})
+	cfg := getDefaultConfig()
+	gState, urlSlice := preSetupTest(cfg, "2025", finished, t)
+	gState.WordList = append(gState.WordList, "badrobots.txt")
+	found := postSetupTest(urlSlice, gState)
+	gState.Wait()
+	if x, ok := found["/badrobots.txt"]; ok || x != nil {
+		t.Error(fmt.Sprintf("Failed test, did not expect to find %s", "/badrobots.txt (bad body contents)"))
+	}
+
+}
+
 func postSetupTest(urlSlice []string, gState *recursebuster.State) (found map[string]*http.Response) {
 	//start up the management goroutines
 	go gState.ManageRequests()

--- a/test/testserver/main.go
+++ b/test/testserver/main.go
@@ -69,6 +69,57 @@ Disallow: /cgi-bin/
 Disallow: /tmp/
 Disallow: /junk/
 `
+const badRobotsBod = `<!doctype html>
+<html>
+<head>
+    <title>Example Domain</title>
+
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style type="text/css">
+    body {
+        background-color: #f0f0f2;
+        margin: 0;
+        padding: 0;
+        font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+        
+    }
+    div {
+        width: 600px;
+        margin: 5em auto;
+        padding: 50px;
+        background-color: #fff;
+        border-radius: 1em;
+    }
+    a:link, a:visited {
+        color: #38488f;
+        text-decoration: none;
+    }
+    @media (max-width: 700px) {
+        body {
+            background-color: #fff;
+        }
+        div {
+            width: auto;
+            margin: 0 auto;
+            border-radius: 0;
+            padding: 1em;
+        }
+    }
+    </style>    
+</head>
+
+<body>
+<div>
+    <h1>Example Domain</h1>
+    <p>This domain is established to be used for illustrative examples in documents. You may use this
+    domain in examples without prior coordination or asking for permission.</p>
+    <p><a href="http://www.iana.org/domains/example">More information...</a></p>
+</div>
+</body>
+</html>
+`
 
 func (ts *TestServer) handler(w http.ResponseWriter, r *http.Request) {
 
@@ -227,6 +278,11 @@ func (ts *TestServer) handler(w http.ResponseWriter, r *http.Request) {
 	case "/headonly":
 		if r.Method == "HEAD" {
 			respCode = 200
+		}
+	case "/badrobots.txt":
+		if r.Method == "GET" {
+			respCode = 200
+			bod = badRobotsBod
 		}
 	case "/robots.txt":
 		if r.Method == "GET" {

--- a/test/testserver/main.go
+++ b/test/testserver/main.go
@@ -279,15 +279,16 @@ func (ts *TestServer) handler(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "HEAD" {
 			respCode = 200
 		}
-	case "/badrobots.txt":
-		if r.Method == "GET" {
-			respCode = 200
-			bod = badRobotsBod
-		}
 	case "/robots.txt":
-		if r.Method == "GET" {
+		if r.Header.Get("badrobotman") == "lol" {
+			bod = badRobotsBod
 			respCode = 200
+			break
+		}
+		if r.Method == "GET" {
 			bod = robotsBod
+			respCode = 200
+			break
 		}
 	case "/robotsfolder/x":
 	case "/vhost1":


### PR DESCRIPTION
Fixed the shonky robots.txt detection with an even shonkier patch. When encountering a robots.txt file now, recursebuster will ensure that no html tag exists!

Longer term I would like to see robots extraction converted to a regular expression system (e.g. ignore all the non-interesting stuff, then regex potential valid url paths) rather than depending on the current approach (which will be fraught with additional problems).

Edit: now with more tests!